### PR TITLE
security valnerability

### DIFF
--- a/src/backend/contracts/Marketplace.sol
+++ b/src/backend/contracts/Marketplace.sol
@@ -49,6 +49,12 @@ contract Marketplace is ReentrancyGuard {
 
     // Make item to offer on the marketplace
     function makeItem(IERC721 _nft, uint _tokenId, uint _price) external nonReentrant {
+         require(_nft.ownerOf(_tokenId) == msg.sender, "not the token owner");
+         require(
+            _nft.isApprovedForAll(msg.sender, address(this)) || 
+            _nft.getApproved(_tokenId) == address(this),
+            "not approved for marketplace"
+        );
         require(_price > 0, "Price must be greater than zero");
         // increment itemCount
         itemCount ++;


### PR DESCRIPTION
checks if the caller is the owner of the nft and also checks if our contract is approved to move the token. using item id for listed items mapping is not a good way because there is no way to know the nft is already listed or not